### PR TITLE
Renaming the package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
-Package: vaccine.equity
+Package: multigroup.vaccine
 Type: Package
-Title: Vaccine Equity Model
+Title: Multigroup Vaccine Model
 Version: 0.1.0
 Authors@R:
     c(person("Damon", "Toth", , "damon.toth@hsc.utah.edu", role = c("aut", "ctb"),
@@ -30,4 +30,4 @@ Suggests:
 Config/testthat/edition: 3
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
-URL: https://epiforesite.github.io/vaccine-equity-model/
+URL: https://epiforesite.github.io/multigroup-vaccine/

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
 YEAR: 2024
-COPYRIGHT HOLDER: vaccine.equity authors
+COPYRIGHT HOLDER: multigroup.vaccine authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2024 vaccine.equity authors
+Copyright (c) 2024 multigroup.vaccine authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/R/run.R
+++ b/R/run.R
@@ -27,6 +27,6 @@
 
 run_my_app <- function(...) {
   shiny::shinyAppDir(
-    system.file("app/", package = "vaccine.equity")
+    system.file("app/", package = "multigroup.vaccine")
   )
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-# Vaccine Equity Model
+# Multigroup Vaccine Model
 [![ForeSITE Group](https://github.com/EpiForeSITE/software/raw/e82ed88f75e0fe5c0a1a3b38c2b94509f122019c/docs/assets/foresite-software-badge.svg)](https://github.com/EpiForeSITE)
-
-Vaccine Equity Model
 
 ## Getting Started
 
@@ -18,14 +16,14 @@ Install the package from github using the [remotes](https://cran.r-project.org/p
 the Shiny application with the run_my_app() function.
 
 ```r
-remotes::install_github("EpiForeSITE/vaccine-equity-model")
-vaccine.equity::run_my_app()
+remotes::install_github("EpiForeSITE/multigroup-vaccine")
+multigroup.vaccine::run_my_app()
 ```
 
 ### Usage
 
 Change the values in the population setup and disease parameters panel to see the effects on the outcomes for the two sub-populations.
-![Screen shot of Vaccine Equity Application](https://raw.githubusercontent.com/EpiForeSITE/vaccine-equity-model/refs/heads/main/inst/app/www/figs/screenshot.PNG)
+![Screen shot of Multigroup Vaccine Application](https://raw.githubusercontent.com/EpiForeSITE/multigroup-vaccine/refs/heads/main/inst/app/www/figs/screenshot.PNG)
 
 ## License
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,3 @@
-url: https://epiforesite.github.io/vaccine-equity-model/
+url: https://epiforesite.github.io/multigroup-vaccine
 template:
   bootstrap: 5

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -6,6 +6,6 @@
 #' @export
 run_model <- function() {
   shinyAppDir(
-    system.file("app/", package = "vaccine.equity")
+    system.file("app/", package = "multigroup.vaccine")
   )
 }

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -1,5 +1,5 @@
 library(shiny)
-library(vaccine.equity)
+library(multigroup.vaccine)
 
 
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -163,7 +163,7 @@ ui <- page_fluid(
       "About",
       h3("Abstract:"),
       p(
-        "Addressing disparities in vaccine uptake through equity-targeted outreach programs requires additional funding, but the cost and outcome trade-offs are not well-understood. This study compared the overall and distributional health and cost outcomes of different vaccination programs."
+        "Addressing disparities in vaccine uptake through targeted outreach programs requires additional funding, but the cost and outcome trade-offs are not well-understood. This study compared the overall and distributional health and cost outcomes of different vaccination programs."
       ),
       tags$i("D. Nguyen1 ∙ K. Duong2 ∙ E. Coates3 ∙ R.E. Nelson4 ∙ J. Love4 ∙ M.M. Jones4 ∙ M. Samore5 ∙ N. Chaiyakunapruk6 ∙ D. Toth"),
       a("https://doi.org/10.1016/j.jval.2024.03.039", href = "https://doi.org/10.1016/j.jval.2024.03.039", class = "link-class", id = "paper_link"),

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -7,6 +7,6 @@
 # * https://testthat.r-lib.org/articles/special-files.html
 
 library(testthat)
-library(vaccine.equity)
+library(multigroup.vaccine)
 
-test_check("vaccine.equity")
+test_check("multigroup.vaccine")

--- a/tests/testthat/test-final_size.R
+++ b/tests/testthat/test-final_size.R
@@ -1,8 +1,8 @@
-library(vaccine.equity)
+library(multigroup.vaccine)
 
 
 test_that("final size calculation works", {
-  ret <- vaccine.equity::getFinalSize(0, c(0.1, 0.1), c(80000, 20000), 1.5, 1 / 7, 1.7, c(0.4, 0.4), 1)
+  ret <- multigroup.vaccine::getFinalSize(0, c(0.1, 0.1), c(80000, 20000), 1.5, 1 / 7, 1.7, c(0.4, 0.4), 1)
   expect_vector(ret, 2)
 
   ret1 <- ret[1]

--- a/vignettes/run_model_on_command_line.Rmd
+++ b/vignettes/run_model_on_command_line.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 ```
 
 ```{r setup}
-library(vaccine.equity)
+library(multigroup.vaccine)
 ```
 
 Consider a population with the following parameters:
@@ -36,7 +36,7 @@ Consider a population with the following parameters:
 -   Susceptibility ratio is the susceptibility of individuals in population B over that of individuals in population A. With susceptibility = 1, they are equally susceptible.
 
 ```{r}
-vaccine.equity::getFinalSize(vacTime = 0,
+multigroup.vaccine::getFinalSize(vacTime = 0,
   vacPortion = c(0.3, 0.2),
   popSize = c(80000, 20000),
   R0 = 1.75,

--- a/vignettes/sensitivity_analysis.Rmd
+++ b/vignettes/sensitivity_analysis.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 ```
 
 ```{r setup}
-library(vaccine.equity)
+library(multigroup.vaccine)
 ```
 
 Consider a population with the following parameters:


### PR DESCRIPTION
This PR changes the name across the project to `multigroup-vaccine` when referring to the repository and `multigroup.vaccine` when referring to the package.